### PR TITLE
chore: rename workflow build to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: build Docker image and publish to github packages
+name: build docker image, publish to github packages and release in the remote server
 
 on:
   release:
@@ -59,7 +59,7 @@ jobs:
             docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE_TAG }}
             docker stop ${{ env.CONTAINER_NAME }} || true
             docker rm ${{ env.CONTAINER_NAME }} || true
-            docker run -d \
+            docker run -d --restar=always\
             --name ${{ env.CONTAINER_NAME }} \
             -p ${{ secrets.HTTP_SERVER_PORT }}:80 \
             -e VUE_APP_API_URL=${{ secrets.BACKEND_URL }} \


### PR DESCRIPTION
## Description

rename workflow `build` to `release`
chore: add --restart=always to docker command
